### PR TITLE
python3 compatibility

### DIFF
--- a/find-emcc.py
+++ b/find-emcc.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
 import os
-execfile(os.path.expanduser("~/.emscripten"))
-print EMSCRIPTEN_ROOT
-
+exec(open(os.path.expanduser("~/.emscripten")).read())
+print(EMSCRIPTEN_ROOT)


### PR DESCRIPTION
On Archlinux python defaults to python 3. So this change allows to run the script with python 3 (there is no execfile in python3).
